### PR TITLE
fix: make create mutation input fields optional for beforeCreate hooks

### DIFF
--- a/.changeset/fix-beforecreate-validation.md
+++ b/.changeset/fix-beforecreate-validation.md
@@ -1,0 +1,9 @@
+---
+"better-auth-convex": patch
+---
+
+Fix beforeCreate hook validation error
+
+Previously, the `create` mutation's input validator required all schema fields to be present, causing validation errors when `beforeCreate` hooks tried to add required fields like `username`.
+
+This fix makes all input fields optional during validation, allowing `beforeCreate` hooks to add or modify any required fields. The actual schema validation still occurs when inserting into the database, ensuring data integrity.


### PR DESCRIPTION
## Summary
- Fixes validation error when beforeCreate hooks try to add required fields
- Makes all input fields optional using partial() for the create mutation
- Allows beforeCreate hooks to properly add/modify required fields like username

## Problem
The create mutation's input validator was requiring all schema fields to be present before the beforeCreate hook could run. This caused validation errors when beforeCreate hooks tried to add required fields (like auto-generating usernames).

## Solution
Used `partial()` from convex-helpers to make all input fields optional during the validation phase. The actual schema validation still happens when inserting into the database, maintaining data integrity.

## Test plan
- [x] beforeCreate hooks can now add required fields without validation errors
- [x] Database constraints are still enforced after hooks run
- [x] Existing create operations continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)