### PR TITLE
Add getAuthUserIdentity helper and improve type safety

### DIFF
--- a/.changeset/helpful-helpers-refactor.md
+++ b/.changeset/helpful-helpers-refactor.md
@@ -1,0 +1,5 @@
+---
+'better-auth-convex': patch
+---
+
+Add `getAuthUserIdentity` helper and improve type safety for session IDs


### PR DESCRIPTION
## Summary
- Add new `getAuthUserIdentity` helper that returns the full identity object with typed `sessionId` and `userId` fields
- Refactor existing `getAuthUserId` to use `getAuthUserIdentity` internally
- Improve type safety for `sessionId` parameter in `getSession` function
- Remove unnecessary type assertions

## Benefits
- Provides access to the complete identity object when needed
- Better type safety with properly typed session and user IDs
- Maintains backward compatibility with existing `getAuthUserId` function
- Cleaner code with reduced type assertions

## Test plan
- [ ] Verify `getAuthUserId` still returns the same value as before
- [ ] Verify `getAuthUserIdentity` returns the full identity object with typed fields
- [ ] Verify `getSession` works correctly with improved types

🤖 Generated with [Claude Code](https://claude.com/claude-code)